### PR TITLE
Remove the local cache path and use object storage only

### DIFF
--- a/.buildkite/scripts/release_to_s3.sh
+++ b/.buildkite/scripts/release_to_s3.sh
@@ -11,5 +11,11 @@ goreleaser release --snapshot --clean
 for i in `ls -1 dist/*.gz`
 do
 echo $i
-aws s3 cp $i s3://${RELEASE_BUCKET}/zstash/
+aws s3 cp $i s3://${RELEASE_BUCKET_USA}/zstash/
+done
+
+for i in `ls -1 dist/*.gz`
+do
+echo $i
+aws s3 cp $i s3://${RELEASE_BUCKET_EU}/zstash/
 done

--- a/internal/commands/save.go
+++ b/internal/commands/save.go
@@ -24,7 +24,6 @@ import (
 
 type SaveCmd struct {
 	Key                string   `flag:"key" help:"Key to save, this can be a template string."`
-	LocalCachePath     string   `flag:"local-cache-path" help:"Local cache path." env:"LOCAL_CACHE_PATH" required:"true"`
 	RemoteCacheURL     string   `flag:"remote-cache-url" help:"Remote cache URL." env:"REMOTE_CACHE_URL"`
 	ExpiresInSecs      int64    `flag:"expires-in-secs" help:"Expires in seconds." default:"86400"`
 	EncoderConcurrency int      `flag:"encoder-concurrency" help:"Zstd Encoder concurrency." default:"8"`
@@ -60,7 +59,15 @@ func (cmd *SaveCmd) Run(ctx context.Context, globals *Globals) error {
 		return fmt.Errorf("failed to build files from disk: %w", err)
 	}
 
-	outputPath := buildOutputPath(cmd.LocalCachePath, key, format)
+	dname, err := os.MkdirTemp("", "zstash-save")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer func(d string) {
+		_ = os.RemoveAll(d)
+	}(dname)
+
+	outputPath := buildOutputPath(dname, key, format)
 
 	sha256sum, err := saveArchive(ctx, format, files, outputPath)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -27,12 +27,10 @@ func main() {
 
 	ctx := context.Background()
 
-	exp, err := trace.NewExporter(ctx)
+	tp, err := trace.NewProvider(ctx, "github.com/buildkite/zstash", version)
 	if err != nil {
-		log.Fatalf("failed to create trace exporter: %v", err)
+		log.Fatalf("failed to create trace provider: %v", err)
 	}
-
-	tp := trace.NewProvider("github.com/buildkite/zstash", exp)
 	defer func() {
 		_ = tp.Shutdown(ctx)
 	}()


### PR DESCRIPTION
I have removed the local cache volumes for a couple of reasons:

1. If a user wants to remove an object from the cache it is useful to have one place to do that, given cloud storage is easier to access and remove I chose thate.
2. The cache volumes hit rate is very low.
3. The restore performance from this volume seemed slow so I want to compare with the local ssd.