### PR TITLE
refactor: updated restore command to break up the core function

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/buildkite/zstash/internal/trace"
 	"github.com/google/go-querystring/query"
@@ -50,9 +51,12 @@ type CacheRetrieveReq struct {
 }
 
 type CacheRetrieveResp struct {
-	Multipart            bool     `json:"multipart"`
-	DownloadInstructions []string `json:"download_instructions"`
-	Message              string   `json:"message"`
+	Key                  string    `json:"key"`      // The key of the cache entry, we MUST to cater for fallbacks
+	Fallback             bool      `json:"fallback"` // Indicates if this is a fallback cache entry
+	ExpiresAt            time.Time `json:"expires_at"`
+	Multipart            bool      `json:"multipart"`
+	DownloadInstructions []string  `json:"download_instructions"`
+	Message              string    `json:"message"`
 }
 
 type CacheCreateResp struct {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -51,7 +51,7 @@ type CacheRetrieveReq struct {
 }
 
 type CacheRetrieveResp struct {
-	Key                  string    `json:"key"`      // The key of the cache entry, we MUST to cater for fallbacks
+	Key                  string    `json:"key"`      // The key of the cache entry, we MUST use this in rest of the restore process to cater for fallbacks
 	Fallback             bool      `json:"fallback"` // Indicates if this is a fallback cache entry
 	ExpiresAt            time.Time `json:"expires_at"`
 	Multipart            bool      `json:"multipart"`


### PR DESCRIPTION
* Simplify and break up restore into a few phases and create functions for them, then combine them in the original command Run function.
* Includes the newly updated API for retrieve which includes fallback, and expires so we can road test those changes.