### PR TITLE
fix: add a flag for recursive checksum generation and disable by default

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -26,7 +26,7 @@ func checkPath(path string) ([]string, error) {
 	return paths, nil
 }
 
-func restoreKeys(id, restoreKeyList string) ([]string, error) {
+func restoreKeys(id, restoreKeyList string, recursive bool) ([]string, error) {
 	restoreKeyTemplates := strings.FieldsFunc(restoreKeyList, func(c rune) bool {
 		return c == '\n' || c == '\r'
 	})
@@ -42,7 +42,7 @@ func restoreKeys(id, restoreKeyList string) ([]string, error) {
 
 		log.Debug().Str("restore_key_template", restoreKeyTemplate).Msg("templating restore key")
 
-		restoreKey, err := key.Template(id, restoreKeyTemplate)
+		restoreKey, err := key.Template(id, restoreKeyTemplate, recursive)
 		if err != nil {
 			return nil, fmt.Errorf("failed to template restore key: %w", err)
 		}

--- a/internal/commands/keytest.go
+++ b/internal/commands/keytest.go
@@ -8,12 +8,13 @@ import (
 )
 
 type KeyTestCmd struct {
-	ID  string `arg:"" help:"ID of the cache entry to test." required:"true"`
-	Key string `arg:"" help:"The key to test." required:"true"`
+	ID                 string `arg:"" help:"ID of the cache entry to test." required:"true"`
+	Key                string `arg:"" help:"The key to test." required:"true"`
+	RecursiveChecksums bool   `flag:"recursive-checksums" help:"Recursively search for matches when generating cache keys."`
 }
 
 func (c *KeyTestCmd) Run(ctx context.Context) error {
-	key, err := key.Template(c.ID, c.Key)
+	key, err := key.Template(c.ID, c.Key, c.RecursiveChecksums)
 	if err != nil {
 		return fmt.Errorf("failed to template key: %w", err)
 	}

--- a/internal/commands/restore.go
+++ b/internal/commands/restore.go
@@ -28,17 +28,18 @@ const (
 )
 
 type RestoreCmd struct {
-	ID           string `flag:"id" help:"ID of the cache entry to restore." required:"true"`
-	Key          string `flag:"key" help:"Key of the cache entry to restore, this can be a template string." required:"true"`
-	FallbackKeys string `flag:"fallback-keys" help:"Fallback keys to use, this is a comma delimited list of key template strings."`
-	Store        string `flag:"store" help:"store used to upload / download" enum:"s3" default:"s3"`
-	Format       string `flag:"format" help:"the format of the archive" enum:"zip" default:"zip"`
-	Paths        string `flag:"paths" help:"Paths within the cache archive to restore to the restore path."`
-	Organization string `flag:"organization" help:"The organization to use." env:"BUILDKITE_ORGANIZATION_SLUG"`
-	Branch       string `flag:"branch" help:"The branch to use." env:"BUILDKITE_BRANCH"`
-	Pipeline     string `flag:"pipeline" help:"The pipeline to use." env:"BUILDKITE_PIPELINE_SLUG"`
-	BucketURL    string `flag:"bucket-url" help:"The bucket URL to use." env:"BUILDKITE_CACHE_BUCKET_URL"`
-	Prefix       string `flag:"prefix" help:"The prefix to use." env:"BUILDKITE_CACHE_PREFIX"`
+	ID                 string `flag:"id" help:"ID of the cache entry to restore." required:"true"`
+	Key                string `flag:"key" help:"Key of the cache entry to restore, this can be a template string." required:"true"`
+	FallbackKeys       string `flag:"fallback-keys" help:"Fallback keys to use, this is a comma delimited list of key template strings."`
+	RecursiveChecksums bool   `flag:"recursive-checksums" help:"Recursively search for matches when generating cache keys."`
+	Store              string `flag:"store" help:"store used to upload / download" enum:"s3" default:"s3"`
+	Format             string `flag:"format" help:"the format of the archive" enum:"zip" default:"zip"`
+	Paths              string `flag:"paths" help:"Paths within the cache archive to restore to the restore path."`
+	Organization       string `flag:"organization" help:"The organization to use." env:"BUILDKITE_ORGANIZATION_SLUG"`
+	Branch             string `flag:"branch" help:"The branch to use." env:"BUILDKITE_BRANCH"`
+	Pipeline           string `flag:"pipeline" help:"The pipeline to use." env:"BUILDKITE_PIPELINE_SLUG"`
+	BucketURL          string `flag:"bucket-url" help:"The bucket URL to use." env:"BUILDKITE_CACHE_BUCKET_URL"`
+	Prefix             string `flag:"prefix" help:"The prefix to use." env:"BUILDKITE_CACHE_PREFIX"`
 }
 
 func (cmd *RestoreCmd) Run(ctx context.Context, globals *Globals) error {
@@ -157,12 +158,12 @@ func (cmd *RestoreCmd) validateAndPrepare(ctx context.Context, span oteltrace.Sp
 		return nil, trace.NewError(span, "failed to check paths: %w", err)
 	}
 
-	cacheKey, err := key.Template(cmd.ID, cmd.Key)
+	cacheKey, err := key.Template(cmd.ID, cmd.Key, cmd.RecursiveChecksums)
 	if err != nil {
 		return nil, trace.NewError(span, "failed to template key: %w", err)
 	}
 
-	fallbackCacheKeys, err := restoreKeys(cmd.ID, cmd.FallbackKeys)
+	fallbackCacheKeys, err := restoreKeys(cmd.ID, cmd.FallbackKeys, cmd.RecursiveChecksums)
 	if err != nil {
 		return nil, trace.NewError(span, "failed to restore keys: %w", err)
 	}

--- a/internal/commands/save.go
+++ b/internal/commands/save.go
@@ -20,18 +20,19 @@ import (
 )
 
 type SaveCmd struct {
-	ID           string `flag:"id" help:"ID of the cache entry to save." required:"true"`
-	Key          string `flag:"key" help:"Key of the cache entry to save, this can be a template string." required:"true"`
-	FallbackKeys string `flag:"fallback-keys" help:"Fallback keys to use, this is a comma delimited list of key template strings."`
-	Store        string `flag:"store" help:"store used to upload / download" enum:"s3" default:"s3"`
-	Format       string `flag:"format" help:"the format of the archive" enum:"zip" default:"zip"`
-	Paths        string `flag:"paths" help:"Paths to remove."`
-	Organization string `flag:"organization" help:"The organization to use." env:"BUILDKITE_ORGANIZATION_SLUG" required:"true"`
-	Branch       string `flag:"branch" help:"The branch to use." env:"BUILDKITE_BRANCH" required:"true"`
-	Pipeline     string `flag:"pipeline" help:"The pipeline to use." env:"BUILDKITE_PIPELINE_SLUG" required:"true"`
-	BucketURL    string `flag:"bucket-url" help:"The bucket URL to use." env:"BUILDKITE_CACHE_BUCKET_URL"`
-	Prefix       string `flag:"prefix" help:"The prefix to use." env:"BUILDKITE_CACHE_PREFIX"`
-	Skip         bool   `help:"Skip saving the cache entry." env:"BUILDKITE_CACHE_SKIP"`
+	ID                 string `flag:"id" help:"ID of the cache entry to save." required:"true"`
+	Key                string `flag:"key" help:"Key of the cache entry to save, this can be a template string." required:"true"`
+	FallbackKeys       string `flag:"fallback-keys" help:"Fallback keys to use, this is a comma delimited list of key template strings."`
+	RecursiveChecksums bool   `flag:"recursive-checksums" help:"Recursively search for matches when generating cache keys."`
+	Store              string `flag:"store" help:"store used to upload / download" enum:"s3" default:"s3"`
+	Format             string `flag:"format" help:"the format of the archive" enum:"zip" default:"zip"`
+	Paths              string `flag:"paths" help:"Paths to remove."`
+	Organization       string `flag:"organization" help:"The organization to use." env:"BUILDKITE_ORGANIZATION_SLUG" required:"true"`
+	Branch             string `flag:"branch" help:"The branch to use." env:"BUILDKITE_BRANCH" required:"true"`
+	Pipeline           string `flag:"pipeline" help:"The pipeline to use." env:"BUILDKITE_PIPELINE_SLUG" required:"true"`
+	BucketURL          string `flag:"bucket-url" help:"The bucket URL to use." env:"BUILDKITE_CACHE_BUCKET_URL"`
+	Prefix             string `flag:"prefix" help:"The prefix to use." env:"BUILDKITE_CACHE_PREFIX"`
+	Skip               bool   `help:"Skip saving the cache entry." env:"BUILDKITE_CACHE_SKIP"`
 }
 
 func (cmd *SaveCmd) Run(ctx context.Context, globals *Globals) error {
@@ -55,7 +56,7 @@ func (cmd *SaveCmd) Run(ctx context.Context, globals *Globals) error {
 		return nil
 	}
 
-	tkey, err := key.Template(cmd.ID, cmd.Key)
+	tkey, err := key.Template(cmd.ID, cmd.Key, cmd.RecursiveChecksums)
 	if err != nil {
 		return trace.NewError(span, "failed to template key: %w", err)
 	}
@@ -85,7 +86,7 @@ func (cmd *SaveCmd) Run(ctx context.Context, globals *Globals) error {
 		return trace.NewError(span, "failed to check paths: %w", err)
 	}
 
-	fallbackKeys, err := restoreKeys(cmd.ID, cmd.FallbackKeys)
+	fallbackKeys, err := restoreKeys(cmd.ID, cmd.FallbackKeys, cmd.RecursiveChecksums)
 	if err != nil {
 		return trace.NewError(span, "failed to restore keys: %w", err)
 	}

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -23,10 +23,10 @@ var ignoreFiles = []string{
 	".idea",
 }
 
-func Template(id, key string) (string, error) {
+func Template(id, key string, recursive bool) (string, error) {
 	tpl := template.New("key").Option("missingkey=zero").Funcs(template.FuncMap{
 		"id":       getID(id),
-		"checksum": checksumPaths,
+		"checksum": checksumPaths(recursive),
 		"env":      getEnv,
 		"agent":    getAgent,
 	})
@@ -82,85 +82,86 @@ func getEnv(key string) string {
 	return env
 }
 
-func checksumPaths(files ...string) string {
+func checksumPaths(recursive bool) func(files ...string) string {
+	return func(files ...string) string {
+		log.Info().Strs("files", files).Msg("checksumPaths")
 
-	log.Info().Strs("files", files).Msg("checksumPaths")
-
-	if len(files) == 0 {
-		return ""
-	}
-
-	sums := []string{}
-
-	for _, filename := range files {
-
-		log.Debug().Str("file", filename).Msg("checksumPaths file")
-
-		// recursively find any files or directories which match the file
-		matchedFiles, matchedDirs, err := matchFilesAndDirs(filename)
-		if err != nil {
-			log.Error().Err(err).Str("file", filename).Msg("error matching files and directories")
+		if len(files) == 0 {
 			return ""
 		}
 
-		log.Info().Int("dirs", len(matchedDirs)).Int("filenames", len(matchedFiles)).Msg("found files and directories")
+		sums := []string{}
 
-		if len(matchedFiles) == 0 && len(matchedDirs) == 0 {
-			log.Warn().Str("file", filename).Msg("no files or directories found")
-			return ""
-		}
+		for _, filename := range files {
 
-		for _, file := range matchedFiles {
-			// if the file is a regular file, we can read it and get the checksum
-			data, err := os.ReadFile(file)
+			log.Debug().Str("file", filename).Msg("checksumPaths file")
+
+			// recursively find any files or directories which match the file
+			matchedFiles, matchedDirs, err := matchFilesAndDirs(filename, recursive)
 			if err != nil {
-				log.Error().Err(err).Str("file", file).Msg("error reading file")
+				log.Error().Err(err).Str("file", filename).Msg("error matching files and directories")
 				return ""
 			}
-			sums = append(sums, checksum(data))
-			log.Debug().Str("file", file).Msg("checksum file")
-		}
 
-		for _, dir := range matchedDirs {
-			// if the file is a directory, we need to walk the directory and get the checksums of all files in the directory
-			log.Debug().Str("dir", dir).Msg("walking directory")
-			err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			log.Info().Int("dirs", len(matchedDirs)).Int("filenames", len(matchedFiles)).Msg("found files and directories")
+
+			if len(matchedFiles) == 0 && len(matchedDirs) == 0 {
+				log.Warn().Str("file", filename).Msg("no files or directories found")
+				return ""
+			}
+
+			for _, file := range matchedFiles {
+				// if the file is a regular file, we can read it and get the checksum
+				data, err := os.ReadFile(file)
 				if err != nil {
-					log.Error().Err(err).Str("path", path).Msg("error walking directory")
-					return err
-				}
-				log.Debug().Str("path", path).Msg("walking path in directory")
-				if info.IsDir() {
-					log.Debug().Str("path", path).Msg("skipping directory")
-					return nil
-				}
-				// read the file and get the checksum
-				data, err := os.ReadFile(path)
-				if err != nil {
-					log.Error().Err(err).Str("file", path).Msg("error reading file in directory")
-					return err
+					log.Error().Err(err).Str("file", file).Msg("error reading file")
+					return ""
 				}
 				sums = append(sums, checksum(data))
-				log.Debug().Str("file", path).Msg("read file in directory")
-				return nil
-			})
-			if err != nil {
-				log.Error().Err(err).Str("dir", dir).Msg("error walking directory")
-				return ""
+				log.Debug().Str("file", file).Msg("checksum file")
+			}
+
+			for _, dir := range matchedDirs {
+				// if the file is a directory, we need to walk the directory and get the checksums of all files in the directory
+				log.Debug().Str("dir", dir).Msg("walking directory")
+				err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						log.Error().Err(err).Str("path", path).Msg("error walking directory")
+						return err
+					}
+					log.Debug().Str("path", path).Msg("walking path in directory")
+					if info.IsDir() {
+						log.Debug().Str("path", path).Msg("skipping directory")
+						return nil
+					}
+					// read the file and get the checksum
+					data, err := os.ReadFile(path)
+					if err != nil {
+						log.Error().Err(err).Str("file", path).Msg("error reading file in directory")
+						return err
+					}
+					sums = append(sums, checksum(data))
+					log.Debug().Str("file", path).Msg("read file in directory")
+					return nil
+				})
+				if err != nil {
+					log.Error().Err(err).Str("dir", dir).Msg("error walking directory")
+					return ""
+				}
 			}
 		}
+
+		log.Debug().Int("files", len(sums)).Msg("checksums calculated")
+
+		// combine the sums into a single string
+		combinedSums := strings.Join(sums, "")
+
+		// use sha256 to get the checksum of the combined hashes
+		return checksum([]byte(combinedSums))
 	}
-
-	log.Debug().Int("files", len(sums)).Msg("checksums calculated")
-
-	// combine the sums into a single string
-	combinedSums := strings.Join(sums, "")
-
-	// use sha256 to get the checksum of the combined hashes
-	return checksum([]byte(combinedSums))
 }
 
-func matchFilesAndDirs(filename string) ([]string, []string, error) {
+func matchFilesAndDirs(filename string, recursive bool) ([]string, []string, error) {
 	matchedDirs := []string{}
 	matchedFiles := []string{}
 
@@ -171,6 +172,12 @@ func matchFilesAndDirs(filename string) ([]string, []string, error) {
 		}
 
 		log.Debug().Str("path", path).Msg("walking path")
+
+		// skip subdirectories if not recursive
+		if !recursive && info.IsDir() && path != "." {
+			log.Debug().Str("path", path).Msg("skipping subdirectory (non-recursive)")
+			return filepath.SkipDir
+		}
 
 		// skip if the file is in the ignore list
 		for _, ignore := range ignoreFiles {

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 
 		Save    commands.SaveCmd    `cmd:"" help:"save files."`
 		Restore commands.RestoreCmd `cmd:"" help:"restore files."`
-		KeyTest commands.KeyTestCmd `cmd:"" help:"test a key."`
+		KeyTest commands.KeyTestCmd `cmd:"" help:"test a key." hidden:""`
 	}
 )
 


### PR DESCRIPTION
When we run bundle install we generate a Gemfile.lock. When we run bundle install --deployment we install all gems into the vendor/bundle folder (and these gems can include Gemfile.lock files inside them). With recursive search for Gemfile.lock we add these new files to the checksum when we save the cache resulting in misses next restore.

https://linear.app/buildkite/issue/MDC-550
