### PR TITLE
fix: this enables us to checksum a specific file in the key

### DIFF
--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -166,7 +166,7 @@ func matchFilesAndDirs(filename string, recursive bool) ([]string, []string, err
 	matchedFiles := []string{}
 
 	// Check if the filename is a specific relative path (contains directory separators)
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+	if filepath.Dir(filename) != "." {
 		// Handle as a specific relative path
 		cleanPath := filepath.Clean(filename)
 		info, err := os.Stat(cleanPath)

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -165,6 +165,25 @@ func matchFilesAndDirs(filename string, recursive bool) ([]string, []string, err
 	matchedDirs := []string{}
 	matchedFiles := []string{}
 
+	// Check if the filename is a specific relative path (contains directory separators)
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+		// Handle as a specific relative path
+		cleanPath := filepath.Clean(filename)
+		info, err := os.Stat(cleanPath)
+		if err != nil {
+			log.Debug().Err(err).Str("path", cleanPath).Msg("specific path not found")
+			return matchedFiles, matchedDirs, nil
+		}
+
+		if info.IsDir() {
+			matchedDirs = append(matchedDirs, cleanPath)
+		} else {
+			matchedFiles = append(matchedFiles, cleanPath)
+		}
+		return matchedFiles, matchedDirs, nil
+	}
+
+	// Original logic for matching by basename
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Error().Err(err).Str("path", path).Msg("error walking path")

--- a/internal/key/key_test.go
+++ b/internal/key/key_test.go
@@ -150,6 +150,21 @@ func TestTemplate(t *testing.T) {
 				},
 				expected: "",
 			},
+			{
+				name:      "file path non-recursive",
+				key:       `{{checksum "testdir/Dockerfile.dev"}}`,
+				recursive: false,
+				setup: func() error {
+					if err := os.Mkdir("testdir", 0755); err != nil {
+						return err
+					}
+					return os.WriteFile(filepath.Join("testdir", "Dockerfile.dev"), []byte("test content"), 0600)
+				},
+				cleanup: func() {
+					_ = os.RemoveAll("testdir")
+				},
+				expected: "4b9054a7a40e53c2e310fcd6f696c46c6a40dcdfa5b849785a456756ec512660",
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
In the example test I want to just checksum a specific dockerfile and use that as the checksum in the key.

This enables something like.
```
        key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum ".buildkite/Dockerfile.dev" }}'
```