### PR TITLE
Add ability to template paths

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -30,13 +30,34 @@ type Globals struct {
 	Common  CommonFlags
 }
 
-// checkPath validates the provided path and returns a list of paths.
-func checkPath(paths []string) ([]string, error) {
-	if len(paths) == 0 {
+// templatedPaths validates the provided path and returns a list of paths that have been templated.
+func templatedPaths(id string, pathsTemplates []string) ([]string, error) {
+	if len(pathsTemplates) == 0 {
 		return nil, fmt.Errorf("no paths provided")
 	}
 
-	return paths, nil
+	resolvedPaths := make([]string, len(pathsTemplates))
+
+	log.Debug().Str("id", id).Strs("paths_templates", pathsTemplates).Msg("templating paths")
+
+	for n, pathTemplate := range pathsTemplates {
+
+		// trim quotes and whitespace
+		resolvedPathTemplate := strings.Trim(pathTemplate, "\"' \t")
+
+		log.Debug().Str("path_template", resolvedPathTemplate).Msg("templating path")
+
+		resolvedPath, err := key.Template(id, resolvedPathTemplate, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve templated path %q: %w", pathTemplate, err)
+		}
+
+		log.Debug().Str("resolved_path", resolvedPath).Msg("resolved path")
+
+		resolvedPaths[n] = resolvedPath
+	}
+
+	return resolvedPaths, nil
 }
 
 // restoreKeys generates a list of restore keys from the provided ID and restore key list.

--- a/internal/commands/restore.go
+++ b/internal/commands/restore.go
@@ -168,7 +168,7 @@ type extractionResult struct {
 }
 
 func (cmd *RestoreCmd) validateAndPrepare(ctx context.Context, span oteltrace.Span, cache Cache) (*restoreData, error) {
-	paths, err := checkPath(cache.Paths)
+	paths, err := templatedPaths(cache.ID, cache.Paths)
 	if err != nil {
 		return nil, trace.NewError(span, "failed to check paths: %w", err)
 	}

--- a/internal/commands/save.go
+++ b/internal/commands/save.go
@@ -172,9 +172,9 @@ type uploadResult struct {
 }
 
 func (cmd *SaveCmd) validateAndPrepare(ctx context.Context, span oteltrace.Span, cache Cache) (*saveData, error) {
-	paths, err := checkPath(cache.Paths)
+	paths, err := templatedPaths(cache.ID, cache.Paths)
 	if err != nil {
-		return nil, trace.NewError(span, "failed to check paths: %w", err)
+		return nil, trace.NewError(span, "failed to template paths: %w", err)
 	}
 
 	cacheKey, err := key.Template(cache.ID, cache.Key, false)


### PR DESCRIPTION
I want to be able to do something like this (where I can inject environment variables into `path` declarations):

`.buildkite/cache.yml`

```yml
# .buildkite/cache.yml
caches:
  - id: "ruby"
    key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum "Gemfile.lock" }}'
    fallback_keys: ["{{ id }}-{{ agent.os }}-{{ agent.arch }}-"]
    paths: "{{ env.BUNDLE_PATH }}"
```

`.buildkite/pipeline.yml`

```yaml
#.buildkite/pipeline.yml
env:
  BUNDLE_FROZEN: true # Don't allow lockfile to mutate during CI
  BUNDLE_PATH: "vendor/bundle"

common:
  - buildkite_cache: &buildkite-cache
      buildkite/zstash#main:
        config: ".buildkite/cache.yml"

steps:
  - label: "Install Ruby dependencies :ruby:"
    key: "install_dependencies"
    command: "bundle install"
    plugins: [*buildkite-cache]

  - label: "Run tests :rspec:"
    key: "run_tests"
    command: "bundle exec rspec ."
    depends_on: ["install_dependencies"]
    plugins: [*buildkite-cache]
```

This PR adds support for templating the `"paths"` value