### PR TITLE
Add 'config' argument to CLI with .buildkite/cache.yml as a default

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	cmd := kong.Parse(&cli,
 		kong.Vars{"version": version, "default_config_path": defaultConfigPath},
 		kong.NamedMapper("yamlfile", kongyaml.YAMLFileMapper),
-		kong.Configuration(kongyaml.Loader, defaultConfigPath),
+		kong.Configuration(kongyaml.Loader),
 		kong.BindTo(ctx, (*context.Context)(nil)))
 
 	// check the token is set

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -17,18 +18,20 @@ import (
 )
 
 var (
-	version = "dev"
+	version           = "dev"
+	defaultConfigPath = ".buildkite/cache.yml"
 
 	cli struct {
 		Version       kong.VersionFlag
-		Debug         bool   `help:"Enable debug mode." default:"false" env:"BUILDKITE_ZSTASH_DEBUG"`
-		Endpoint      string `flag:"endpoint" help:"The endpoint to use. Defaults to the Buildkite agent API endpoint." default:"https://agent.buildkite.com/v3" env:"BUILDKITE_AGENT_API_ENDPOINT"`
-		Token         string `flag:"token" help:"The buildkite agent access token to use." env:"BUILDKITE_AGENT_ACCESS_TOKEN" required:"true"`
-		TraceExporter string `flag:"trace-exporter" help:"The trace exporter to use. Defaults to 'noop'." default:"noop" enum:"noop,grpc" env:"BUILDKITE_ZSTASH_TRACE_EXPORTER"`
+		Debug         bool            `help:"Enable debug mode." default:"false" env:"BUILDKITE_ZSTASH_DEBUG"`
+		Endpoint      string          `flag:"endpoint" help:"The endpoint to use. Defaults to the Buildkite agent API endpoint." default:"https://agent.buildkite.com/v3" env:"BUILDKITE_AGENT_API_ENDPOINT"`
+		Token         string          `flag:"token" help:"The buildkite agent access token to use." env:"BUILDKITE_AGENT_ACCESS_TOKEN" required:"true"`
+		TraceExporter string          `flag:"trace-exporter" help:"The trace exporter to use. Defaults to 'noop'." default:"noop" enum:"noop,grpc" env:"BUILDKITE_ZSTASH_TRACE_EXPORTER"`
+		Config        kong.ConfigFlag `flag:"config" help:"The path to the cache configuration file. Defaults to .buildkite/cache.yml" default:"${default_config_path}" env:"BUILDKITE_CACHE_CONFIG" `
 
 		commands.CommonFlags
 
-		Caches []cache.Cache // embedded configuration for caches
+		Caches []cache.Cache // embedded config
 
 		Save    commands.SaveCmd    `cmd:"" help:"save files."`
 		Restore commands.RestoreCmd `cmd:"" help:"restore files."`
@@ -41,13 +44,14 @@ func main() {
 
 	start := time.Now()
 
+	// Overloads `cli` with configuration file values.
 	cmd := kong.Parse(&cli,
-		kong.Vars{
-			"version": version,
-		},
+		kong.Vars{"version": version, "default_config_path": defaultConfigPath},
 		kong.NamedMapper("yamlfile", kongyaml.YAMLFileMapper),
-		kong.Configuration(kongyaml.Loader, ".buildkite/cache.yaml", ".buildkite/cache.yml", ".buildkite/cache.json"),
+		kong.Configuration(kongyaml.Loader, defaultConfigPath),
 		kong.BindTo(ctx, (*context.Context)(nil)))
+
+	fmt.Printf("Using config file: %s\n", cli.Config)
 
 	// check the token is set
 	if cli.Token == "" {
@@ -76,7 +80,7 @@ func main() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).Level(zerolog.ErrorLevel)
 	}
 
-	err = cmd.Run(&commands.Globals{Debug: cli.Debug, Version: version, Client: client, Printer: printer, Caches: cli.Caches, Common: cli.CommonFlags})
+	err = cmd.Run(&commands.Globals{Debug: cli.Debug, Version: version, Client: client, Printer: printer, Common: cli.CommonFlags, Caches: cli.Caches})
 	span.RecordError(err)
 	cmd.FatalIfErrorf(err)
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -50,8 +49,6 @@ func main() {
 		kong.NamedMapper("yamlfile", kongyaml.YAMLFileMapper),
 		kong.Configuration(kongyaml.Loader, defaultConfigPath),
 		kong.BindTo(ctx, (*context.Context)(nil)))
-
-	fmt.Printf("Using config file: %s\n", cli.Config)
 
 	// check the token is set
 	if cli.Token == "" {


### PR DESCRIPTION
```
Usage: zstash restore --token=STRING [flags]

restore files.

Flags:
  -h, --help                                         Show context-sensitive help.
      --version
      --debug                                        Enable debug mode ($BUILDKITE_ZSTASH_DEBUG).
      --endpoint="https://agent.buildkite.com/v3"    The endpoint to use. Defaults to the Buildkite agent API endpoint ($BUILDKITE_AGENT_API_ENDPOINT).
      --token=STRING                                 The buildkite agent access token to use ($BUILDKITE_AGENT_ACCESS_TOKEN).
      --trace-exporter="noop"                        The trace exporter to use. Defaults to 'noop' ($BUILDKITE_ZSTASH_TRACE_EXPORTER).
      --config=".buildkite/cache.yml"                The path to the cache configuration file. Defaults to .buildkite/cache.yml ($BUILDKITE_CACHE_CONFIG)
      --organization=STRING                          The organization to use ($BUILDKITE_ORGANIZATION_SLUG).
      --branch=STRING                                The branch to use ($BUILDKITE_BRANCH).
      --pipeline=STRING                              The pipeline to use ($BUILDKITE_PIPELINE_SLUG).
      --bucket-url=STRING                            The bucket URL to use ($BUILDKITE_CACHE_BUCKET_URL).
      --format="zip"                                 The format of the archive to use ($BUILDKITE_CACHE_FORMAT).
      --caches=CACHES,...

      --ids=IDS,...                                  List of comma delimited cache IDs to restore, defaults to all ($BUILDKITE_CACHE_IDS).       
```

Removes fallback configuration file values. We can add this back later if we need.